### PR TITLE
Adicionar arquivo de dependências

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Exclude files from the build
+gabinete/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Exclude files from the build
 gabinete/
+
+# Exclude virtual env folder
+venv/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Certifique-se de ter as seguintes dependências instaladas:
    ```bash
    cd utils
 
-3. Instale as dependências
+3. Instale as dependências rodando o seguinte comando dentro do repositório:
+   ```bash
+   pip3 install -r requirements.txt
 
 4. Execute o script
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests==2.31.0
+beautifulsoup4==4.12.2
+Unidecode==1.3.7


### PR DESCRIPTION
- Só adicionei um arquivo de dependências para facilitar a utilização do script. Agora ao invés de instalar manualmente cada dependência, basta apenas rodar o seguinte comando dentro do repositório:
```bash
pip3 install -r requirements.txt
```